### PR TITLE
refact(middleware): replace getArgsLength with the length property

### DIFF
--- a/.changeset/friendly-toys-greet.md
+++ b/.changeset/friendly-toys-greet.md
@@ -1,0 +1,5 @@
+---
+'guarapi': patch
+---
+
+Replaced getArgsLength with the native length property, improving performance and simplifying the code.

--- a/packages/guarapi/src/plugins/middleware.ts
+++ b/packages/guarapi/src/plugins/middleware.ts
@@ -8,15 +8,6 @@ declare module '../types' {
   }
 }
 
-function getArgsLength<T>(fn: T) {
-  return (
-    (fn as () => void)
-      .toString()
-      .replace(/\s+/g, '')
-      .match(/\((.*?)\)/)?.[1] || ''
-  ).split(',').length;
-}
-
 const middlewarePlugin: Plugin = (app) => {
   const middlewares: { path: string; handler: Middleware }[] = [];
   const errorMiddlewares: MiddlewareError[] = [];
@@ -27,7 +18,7 @@ const middlewarePlugin: Plugin = (app) => {
       | Middleware
       | MiddlewareError;
 
-    if (getArgsLength(middlewareHandler) <= 3) {
+    if (middlewareHandler.length <= 3) {
       middlewares.push({
         path: middlewarePath,
         handler: (req, res, next) => {


### PR DESCRIPTION
improve performance in middleware plugin, replacing `getArgsLength` with the native length property.